### PR TITLE
add a --version flag to help hledger-install.sh

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -79,6 +79,7 @@ unmatchedtxns s pp m =
 main :: IO ()
 main = getArgs >>= \args -> case args of
   [acct, f1, f2] -> diffCmd (T.pack acct) f1 f2
+  ["--version"] -> putStrLn "hledger-diff 0.2.0.9"  -- keep synced with hledger-diff.cabal
   _ -> do
     putStrLn "Usage: hledger-diff account:name left.journal right.journal"
     exitFailure


### PR DESCRIPTION
This lets the installer report hledger-diff's installed version
and know when to upgrade it.